### PR TITLE
Separate build version

### DIFF
--- a/Kconfig.sysbuild
+++ b/Kconfig.sysbuild
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config RISCV_CPU
+	string "The cpu used for risc v target"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,47 @@ The following hardware is used for the project:
 	
 	# initialize workspace
 	west init -m https://github.com/SvenHaedrich/hello_dualcore --mr main nRF54L15
-	cd nrf54L15
+	cd nRF54L15
 	west update
 	
 	# install additional tools
 	python3 -m pip install pyelftools
 	python3 -m pip install intelhex
 
-### Build
+### Separate Builds with Merge on Silicon
+
+You can run two seperate builds. This will give you two HEX files.
+
+	west build --board nrf54l15pdk/nrf54l15/cpuapp --build-dir build-app -S nordic-flpr hello_dualcore
+	west build --board nrf54l15pdk/nrf54l15/cpuflpr --build-dir build-risc hello_dualcore
+
+Use the nrf Programmer tool to merge the output and flash the result to your device. You can observe the two serial ports via the devkits´s USB connection. These show up as `/dev/ttyACM0` and `/dev/ttyACM1`. You get the following output on these ports:
+
+	*** Booting nRF Connect SDK v2.7.0-5cb85570ca43 ***
+	*** Using Zephyr OS v3.6.99-100befc70c74 ***
+	Hello World! nrf54l15pdk@0.3.0/nrf54l15/cpuapp
+
+and
+
+	*** Booting nRF Connect SDK v2.7.0-5cb85570ca43 ***
+	*** Using Zephyr OS v3.6.99-100befc70c74 ***
+	Hello World! nrf54l15pdk@0.3.0/nrf54l15/cpuflpr
 
 
+
+### Sysbuild
+
+The canonical way two handle this situation is to use Zephyr's [sysbuild](https://docs.zephyrproject.org/latest/build/sysbuild/index.html). The sysbuild will need some additional configuration files. In this sample
+the sysbuild is driven by `sysbuild.cmake`. As of now that attempt files, there seems to be something rotten in the RISC V device tree configuration.
+
+	west build --board nrf54l15pdk/nrf54l15/cpuapp -S nordic-flpr --sysbuild hello_dualcore -- -DSB_CONFIG_RISCV_CPU='"nrf54l15pdk/nrf54l15/cpuflpr"'
+
+gives, at some point:
+
+```
+-- Found devicetree overlay: /home/sven_gcx/Repos/nRF54L15/zephyr/snippets/nordic-flpr/nordic-flpr.overlay
+devicetree error: 'execution-memory' is marked as required in 'properties:' in /home/sven_gcx/Repos/nRF54L15/zephyr/dts/bindings/riscv/nordic,nrf-vpr-coprocessor.yaml, but does not appear in <Node /soc/peripheral@50000000/vpr@4c000 in '/home/sven_gcx/Repos/nRF54L15/zephyr/misc/empty_file.c'>
+-- In: /home/sven_gcx/Repos/nRF54L15/build/riscv/zephyr, command: /home/sven_gcx/Repos/nRF54L15/.venv/bin/python;/home/sven_gcx/Repos/nRF54L15/zephyr/scripts/dts/gen_defines.py;--dts;/home/sven_gcx/Repos/nRF54L15/build/riscv/zephyr/zephyr.dts.pre;--dtc-flags;'';--bindings-dirs;/home/sven_gcx/Repos/nRF54L15/nrf/dts/bindings;/home/sven_gcx/Repos/nRF54L15/zephyr/dts/bindings;--header-out;/home/sven_gcx/Repos/nRF54L15/build/riscv/zephyr/include/generated/devicetree_generated.h.new;--dts-out;/home/sven_gcx/Repos/nRF54L15/build/riscv/zephyr/zephyr.dts.new;--edt-pickle-out;/home/sven_gcx/Repos/nRF54L15/build/riscv/zephyr/edt.pickle;--vendor-prefixes;/home/sven_gcx/Repos/nRF54L15/nrf/dts/bindings/vendor-prefixes.txt;--vendor-prefixes;/home/sven_gcx/Repos/nRF54L15/zephyr/dts/bindings/vendor-prefixes.txt
+CMake Error at /home/sven_gcx/Repos/nRF54L15/zephyr/cmake/modules/dts.cmake:296 (message):
+  gen_defines.py failed with return code: 1
+```

--- a/riscv/CMakeLists.txt
+++ b/riscv/CMakeLists.txt
@@ -1,8 +1,8 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(hello_dualcore)
 
-target_sources(app PRIVATE src/main.c)
+project(riscv)
+target_sources(app PRIVATE ../src/main.c)

--- a/riscv/prj.conf
+++ b/riscv/prj.conf
@@ -1,0 +1,1 @@
+# no additional configuration is required

--- a/sysbuild.cmake
+++ b/sysbuild.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if("${SB_CONFIG_RISCV_CPU}" STREQUAL "")
+  message(FATAL_ERROR "RISCV_CPU must be set to a valid board name")
+endif()
+
+ExternalZephyrProject_Add(
+  APPLICATION riscv
+  SOURCE_DIR ${APP_DIR}/riscv
+  BOARD ${SB_CONFIG_RISCV_CPU}
+)
+
+add_dependencies(hello_dualcore riscv)
+sysbuild_add_dependencies(FLASH hello_dualcore riscv)


### PR DESCRIPTION
This commit worls with two separate builds
that are merged on the silicon. But files for
sysbuild are included as well. It is just that
this doesn´t work but failes with a device tree
error during the RISC V build portion.